### PR TITLE
[DNM] Fixes #19334 - use status checks for configuration updates

### DIFF
--- a/app/controllers/foreman_virt_who_configure/concerns/virt_who_ping_tracker.rb
+++ b/app/controllers/foreman_virt_who_configure/concerns/virt_who_ping_tracker.rb
@@ -1,0 +1,32 @@
+module ForemanVirtWhoConfigure
+  module Concerns
+    module VirtWhoPingTracker
+      extend ActiveSupport::Concern
+
+      included do
+        before_action :track_ping, :only => :server_status
+      end
+
+      private
+
+      def track_ping
+        username, password = Base64.decode64(request.headers['HTTP_AUTHORIZATION'].split(' ')[-1]).split(':')
+        logger.debug "virt-who status ping received for user #{username}"
+        if AuthSourceHiddenWithAuthentication.default.authenticate(username, password)
+          if (user = User.unscoped.find_by_login(username))
+            config = ::ForemanVirtWhoConfigure::Config.find_by_user(user)
+
+            if config.present?
+              logger.debug "found matching configuration with id #{config.id}"
+              config.virt_who_touch!
+            else
+              logger.debug "matching configuration not found"
+            end
+          else
+            logger.warn "user with username #{username} not found"
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/foreman_virt_who_configure/config/report.rb
+++ b/app/lib/actions/foreman_virt_who_configure/config/report.rb
@@ -20,7 +20,7 @@ module Actions
           #   hypervisor = ::Host.joins(:subscription_facet).where(:'katello_subscription_facets.uuid' => hv_attrs['uuid']).first
           # end
 
-          config = ::ForemanVirtWhoConfigure::ServiceUser.find_by_user_id(User.current.id).try(:config)
+          config = ::ForemanVirtWhoConfigure::Config.find_by_user(User.current)
           if config.present?
             config.virt_who_touch!
           end

--- a/db/migrate/20170502142851_add_reported_data_to_config.rb
+++ b/db/migrate/20170502142851_add_reported_data_to_config.rb
@@ -1,0 +1,5 @@
+class AddReportedDataToConfig < ActiveRecord::Migration
+  def change
+    add_column :foreman_virt_who_configure_configs, :reported_data, :boolean, :null => false, :default => false
+  end
+end

--- a/lib/foreman_virt_who_configure/engine.rb
+++ b/lib/foreman_virt_who_configure/engine.rb
@@ -88,6 +88,9 @@ module ForemanVirtWhoConfigure
     # Include concerns in this config.to_prepare block
     config.to_prepare do
       SSO::METHODS.unshift SSO::BasicWithHidden
+      if ForemanVirtWhoConfigure.with_katello?
+        Katello::Api::Rhsm::CandlepinProxiesController.send(:include, ForemanVirtWhoConfigure::Concerns::VirtWhoPingTracker)
+      end
     end
 
     rake_tasks do

--- a/test/factories/foreman_virt_who_configure_factories.rb
+++ b/test/factories/foreman_virt_who_configure_factories.rb
@@ -15,10 +15,12 @@ FactoryGirl.define do
   trait :out_of_date do
     last_report_at (1.minute.ago - 120.minutes).utc
     out_of_date_at (1.minute.ago).utc
+    reported_data false
   end
 
   trait :ok do
     last_report_at (1.minute.ago).utc
     out_of_date_at (1.minute.ago + 120.minutes).utc
+    reported_data true
   end
 end

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -128,6 +128,18 @@ module ForemanVirtWhoConfigure
         assert_equal out_of_date_config.out_of_date_at, out_of_date_config.last_report_at + out_of_date_config.interval.minutes
       end
 
+      test '#virt_who_touch! sets reported data to true' do
+        refute out_of_date_config.reported_data
+        out_of_date_config.virt_who_touch!
+        assert out_of_date_config.reported_data
+      end
+
+      test '#virt_who_touch!(false) sets reported data to false' do
+        assert ok_config.reported_data
+        ok_config.virt_who_touch!(false)
+        refute ok_config.reported_data
+      end
+
       test '#status returns the symbol representing the current status' do
         assert_equal :ok, ok_config.status
         assert_equal :error, out_of_date_config.status
@@ -138,6 +150,17 @@ module ForemanVirtWhoConfigure
         assert_kind_of String, ok_config.status_description
         assert_kind_of String, out_of_date_config.status_description
         assert_kind_of String, unknown_config.status_description
+      end
+    end
+
+    describe '.find_by_user' do
+      test 'it finds the configuration based on user object' do
+        config.save
+        assert_equal config, ForemanVirtWhoConfigure::Config.find_by_user(config.service_user.user)
+      end
+
+      test 'it returns nil for user that is not linked to any config' do
+        assert_nil ForemanVirtWhoConfigure::Config.find_by_user(FactoryGirl.create(:user))
       end
     end
   end


### PR DESCRIPTION
```
Run options: --seed 34634

# Running:

.................................

Finished in 7.366072s, 4.4800 runs/s, 12.7612 assertions/s.

33 runs, 94 assertions, 0 failures, 0 errors, 0 skips
```