### PR TITLE
Refs #19526 - escape newline

### DIFF
--- a/app/models/foreman_virt_who_configure/output_generator.rb
+++ b/app/models/foreman_virt_who_configure/output_generator.rb
@@ -48,7 +48,7 @@ module ForemanVirtWhoConfigure
       result += "#!/usr/bin/bash\n" if format == :bash_script
       result += <<EOS
 heading() {
-  echo -e "\n== $1 =="
+  echo -e "\\n== $1 =="
 }
 
 step() {


### PR DESCRIPTION
\n in bash function 'heading' was interpreted already in the ruby
string. Functionality is the same but it's visually cleaner if the
newline is escaped in ruby and interpreted in bash.