### PR TITLE
Fixes #21301 - ignore reports for cert auth

### DIFF
--- a/app/lib/actions/foreman_virt_who_configure/config/report.rb
+++ b/app/lib/actions/foreman_virt_who_configure/config/report.rb
@@ -9,7 +9,7 @@ module Actions
         end
 
         def plan(hypervisors)
-          plan_self(:hypervisors => hypervisors)
+          plan_self(:hypervisors => hypervisors) if User.current.try(:id)
         end
 
         def run


### PR DESCRIPTION
virt-who can be configured to use cert-based
authentication, and if that is the case User.current
is actually set to a katello CpConsumerUser which has
no id