### PR TITLE
Fixes #23638 - support shell chards in username

### DIFF
--- a/app/models/foreman_virt_who_configure/output_generator.rb
+++ b/app/models/foreman_virt_who_configure/output_generator.rb
@@ -1,3 +1,5 @@
+require 'shellwords'
+
 module ForemanVirtWhoConfigure
   class OutputGenerator
     class ConfigurationResult
@@ -191,7 +193,7 @@ EOS
     end
 
     def cr_username
-      config.hypervisor_username
+      Shellwords.escape(config.hypervisor_username)
     end
 
     def cr_password


### PR DESCRIPTION
@tstrachota another easy one for review I hope, reproducer - user $ in username, render a script and verify $ is still in resulting config file (not interpolated by shell)