### PR TITLE
Fixes #23878 - Config association with organization

### DIFF
--- a/app/models/concerns/virt_who_taxonomy_extensions.rb
+++ b/app/models/concerns/virt_who_taxonomy_extensions.rb
@@ -1,0 +1,6 @@
+module VirtWhoTaxonomyExtensions
+  extend ActiveSupport::Concern
+  included do
+    has_one :config, :dependent => :destroy, :class_name => 'ForemanVirtWhoConfigure::Config'
+  end
+end

--- a/lib/foreman_virt_who_configure/engine.rb
+++ b/lib/foreman_virt_who_configure/engine.rb
@@ -101,6 +101,7 @@ module ForemanVirtWhoConfigure
     # Include concerns in this config.to_prepare block
     config.to_prepare do
       SSO::METHODS.unshift SSO::BasicWithHidden
+      ::Organization.send :include, VirtWhoTaxonomyExtensions
     end
 
     rake_tasks do


### PR DESCRIPTION
This adds missing dependent destroy of ForemanVirtWhoConfigure::Config class so when deleting the Organization it should consider deleting Virt Who configuration associated with Organization.