### PR TITLE
Fixes #25814 - introduce CNV support

### DIFF
--- a/app/assets/javascripts/foreman_virt_who_configure/config_edit.js
+++ b/app/assets/javascripts/foreman_virt_who_configure/config_edit.js
@@ -26,8 +26,12 @@ function virt_who_update_listing_mode() {
 
 function virt_who_update_hypervisor_fields() {
   selected_type = $('#foreman_virt_who_configure_config_hypervisor_type').val();
+  var element = $('#foreman_virt_who_configure_config_hypervisor_username');
+  element.closest('.form-group').toggle(selected_type != 'kubevirt');
   var element = $('#foreman_virt_who_configure_config_hypervisor_password');
-  element.closest('.form-group').toggle(selected_type != 'libvirt');
+  element.closest('.form-group').toggle(selected_type != 'libvirt' && selected_type != 'kubevirt');
+  var element = $('#foreman_virt_who_configure_config_kubeconfig_path');
+  element.closest('.form-group').toggle(selected_type == 'kubevirt');
 }
 
 function virt_who_update_credentials_help() {

--- a/app/helpers/foreman_virt_who_configure/configs_helper.rb
+++ b/app/helpers/foreman_virt_who_configure/configs_helper.rb
@@ -7,7 +7,8 @@ module ForemanVirtWhoConfigure
         # 'vdsm' => 'Red Hat Enterprise Linux Hypervisor (vdsm)',
         'hyperv' => _('Microsoft Hyper-V fully qualified host name or IP address.'),
         'xen' => _('XenServer server’s fully qualified host name or IP address.'),
-        'libvirt' => _('Libvirt server’s fully qualified host name or IP address. You can also specify preferred schema, for example: <code>qemu+ssh://libvirt.example.com/system</code>. If you use SSH, make sure you setup root\'s SSH key on target host for a user specified at hypervisor username field')
+        'libvirt' => _('Libvirt server’s fully qualified host name or IP address. You can also specify preferred schema, for example: <code>qemu+ssh://libvirt.example.com/system</code>. If you use SSH, make sure you setup root\'s SSH key on target host for a user specified at hypervisor username field'),
+        'kubevirt' => _('Container-native virtualization’s fully qualified host name or IP address. In order to connect to the cluster it is required to provide path to kubeconfig which contains connection details and authentication token.')
       }
     end
 

--- a/app/helpers/foreman_virt_who_configure/configs_helper.rb
+++ b/app/helpers/foreman_virt_who_configure/configs_helper.rb
@@ -19,7 +19,8 @@ module ForemanVirtWhoConfigure
         # 'vdsm' => '',
         'hyperv' => _('Account name by which virt-who is to connect to the hypervisor. By default this is <code>Administrator</code>. To use an alternate account, create a user account and assign that account to the following groups (Windows 2012 Server): Hyper-V Administrators and Remote Management Users.'),
         'xen' => _('Account name by which virt-who is to connect to the hypervisor.'),
-        'libvirt' => _('Account name by which virt-who is to connect to the hypervisor. Virt-who does not support password based authentication, you must manually setup SSH key, see <a href="https://access.redhat.com/solutions/1515983">Red Hat Knowledgebase solution How to configure virt-who for a KVM host</a> for more information.')
+        'libvirt' => _('Account name by which virt-who is to connect to the hypervisor. Virt-who does not support password based authentication, you must manually setup SSH key, see <a href="https://access.redhat.com/solutions/1515983">Red Hat Knowledgebase solution How to configure virt-who for a KVM host</a> for more information.'),
+        'kubevirt' => ''
       }
     end
 

--- a/app/models/foreman_virt_who_configure/config.rb
+++ b/app/models/foreman_virt_who_configure/config.rb
@@ -35,7 +35,8 @@ module ForemanVirtWhoConfigure
       # 'vdsm' => 'Red Hat Enterprise Linux Hypervisor (vdsm)',
       'hyperv' => 'Microsoft Hyper-V (hyperv)',
       'xen' => 'XenServer (xen)',
-      'libvirt' => 'libvirt'
+      'libvirt' => 'libvirt',
+      'kubevirt' => 'Container-native virtualization'
     }
 
     HYPERVISOR_DEFAULT_TYPE = 'esx'

--- a/app/models/foreman_virt_who_configure/config.rb
+++ b/app/models/foreman_virt_who_configure/config.rb
@@ -6,7 +6,7 @@ module ForemanVirtWhoConfigure
       :satellite_url, :proxy, :no_proxy, :name,
       # API parameter filtering_mode gets translated to listing_mode in the controller
       # We keep both params permitted for compatibility with 1.11
-      :listing_mode, :filtering_mode, :filter_host_parents, :exclude_host_parents
+      :listing_mode, :filtering_mode, :filter_host_parents, :exclude_host_parents, :kubeconfig_path
     ]
     audited :except => [ :hypervisor_password, :last_report_at, :out_of_date_at ], :associations => []
     include Authorizable
@@ -92,11 +92,12 @@ module ForemanVirtWhoConfigure
     after_create :create_service_user
     after_destroy :destroy_service_user
 
-    validates :interval, :hypervisor_type, :hypervisor_server, :hypervisor_username,
+    validates :interval, :hypervisor_type, :hypervisor_server,
               :satellite_url, :hypervisor_id, :organization_id, :name,
               :presence => true
     validates :name, :uniqueness => { :scope => :organization_id }
-    validates :hypervisor_password, :presence => true, :if => Proc.new { |c| c.hypervisor_type != 'libvirt' }
+    validates :hypervisor_password, :presence => true, :if => Proc.new { |c| c.hypervisor_type != 'libvirt' && c.hypervisor_type != 'kubevirt' }
+    validates :hypervisor_username, :presence => true, :if => Proc.new { |c| c.hypervisor_type != 'kubevirt' }
     validates :hypervisor_type, :inclusion => HYPERVISOR_TYPES.keys
     validates :hypervisor_id, :inclusion => HYPERVISOR_IDS
     validates :interval, :inclusion => AVAILABLE_INTERVALS.keys.map(&:to_i)

--- a/app/models/foreman_virt_who_configure/output_generator.rb
+++ b/app/models/foreman_virt_who_configure/output_generator.rb
@@ -9,7 +9,7 @@ module ForemanVirtWhoConfigure
       end
     end
 
-    MINIMUM_VIRT_WHO_VERSION = '0.19'
+    MINIMUM_VIRT_WHO_VERSION = '0.24.2'
 
     LIBVIRT_FAKE_PASSWORD = 'libvirt_fake_password'
 
@@ -48,6 +48,7 @@ module ForemanVirtWhoConfigure
     end
 
     def virt_who_output(format = nil)
+      kubeconfig = config.hypervisor_type == 'kubevirt' ? "\nkubeconfig=#{config.kubeconfig_path} : ''
       result = ''
       result += "#!/bin/bash\n" if format == :bash_script
       result += <<EOS
@@ -105,6 +106,7 @@ rhsm_hostname=#{satellite_url}
 rhsm_username=#{service_user_username}
 rhsm_encrypted_password=$user_password
 rhsm_prefix=/rhsm
+#{kubeconfig}
 EOF
   if [ $? -ne 0 ]; then result_code=$(($result_code|#{error_code(:virt_who_config_file_issue)})); fi
 

--- a/app/models/foreman_virt_who_configure/output_generator.rb
+++ b/app/models/foreman_virt_who_configure/output_generator.rb
@@ -48,7 +48,7 @@ module ForemanVirtWhoConfigure
     end
 
     def virt_who_output(format = nil)
-      kubeconfig = config.hypervisor_type == 'kubevirt' ? "\nkubeconfig=#{config.kubeconfig_path} : ''
+      kubeconfig = config.hypervisor_type == 'kubevirt' ? "\nkubeconfig=#{config.kubeconfig_path}" : ''
       result = ''
       result += "#!/bin/bash\n" if format == :bash_script
       result += <<EOS
@@ -105,8 +105,7 @@ encrypted_password=$cr_password#{filtering}
 rhsm_hostname=#{satellite_url}
 rhsm_username=#{service_user_username}
 rhsm_encrypted_password=$user_password
-rhsm_prefix=/rhsm
-#{kubeconfig}
+rhsm_prefix=/rhsm#{kubeconfig}
 EOF
   if [ $? -ne 0 ]; then result_code=$(($result_code|#{error_code(:virt_who_config_file_issue)})); fi
 

--- a/app/views/foreman_virt_who_configure/configs/show.html.erb
+++ b/app/views/foreman_virt_who_configure/configs/show.html.erb
@@ -34,7 +34,7 @@
           <%= config_attribute :status, config_report_status(@config), _('Status') %>
           <%= config_attribute :hypervisor_type, _(ForemanVirtWhoConfigure::Config::HYPERVISOR_TYPES[@config.hypervisor_type]) %>
           <%= config_attribute :hypervisor_server, @config.hypervisor_server %>
-          <%= config_attribute :hypervisor_username, @config.hypervisor_username %>
+          <%= config_attribute :hypervisor_username, @config.hypervisor_username if @config.hypervisor_type != 'kubevirt' %>
           <%= config_attribute :interval, _(ForemanVirtWhoConfigure::Config::AVAILABLE_INTERVALS[@config.interval.to_s]) %>
           <%= config_attribute :satellite_url, @config.satellite_url, _('Satellite server FQDN')%>
           <%= config_attribute :hypervisor_id, @config.hypervisor_id, _('Hypervisor ID') %>
@@ -44,6 +44,7 @@
           <%= config_attribute :debug, checked_icon(@config.debug), _('Enable debugging output?') %>
           <%= config_attribute :proxy, @config.proxy if @config.proxy.present? %>
           <%= config_attribute :no_proxy, @config.no_proxy if @config.no_proxy.present? %>
+          <%= config_attribute :kubeconfig_path, @config.kubeconfig_path if @config.hypervisor_type == 'kubevirt' %>
         </div>
       </div>
     </div>

--- a/app/views/foreman_virt_who_configure/configs/steps/_connection_form.erb
+++ b/app/views/foreman_virt_who_configure/configs/steps/_connection_form.erb
@@ -20,4 +20,5 @@
   <%= checkbox_f f, :debug, { :label => _('Enable debugging output') }.merge(inline_help_popover(_("Different debug value can't be set per hypervisor, therefore it will affect all other deployed configurations on the host on which this configuration will be deployed."))) %>
   <%= text_f f, :proxy, inline_help_popover(_('HTTP proxy that should be used for communication between the server on which virt-who is running and the hypervisors and virtualization managers. Leave this blank if no proxy is used.')).merge(:label => _('HTTP proxy')) %>
   <%= text_f f, :no_proxy, inline_help_popover(_('A comma-separated list of hostnames or domains or ip addresses to ignore proxy settings for. Optionally this may be set to <code>*</code> to bypass proxy settings for all hostnames domains or ip addresses.')).merge(:label => _('Ignore proxy')) %>
+  <%= text_f f, :kubeconfig_path, inline_help_popover(_('Configuration file containing details about how to connect to the cluster and authentication details')).merge(:label => _('Path to kubeconfig file')) %>
 </div>

--- a/db/migrate/20190104125749_add_kubeconfig_to_config.rb
+++ b/db/migrate/20190104125749_add_kubeconfig_to_config.rb
@@ -1,0 +1,5 @@
+class AddKubeconfigToConfig < ActiveRecord::Migration[4.2]
+  def change
+    add_column :foreman_virt_who_configure_configs, :kubeconfig_path, :string, :null => true
+  end
+end


### PR DESCRIPTION
We added support of kubevirt/cnv to virt-who now we are updating hypervisor type hash.
