### PR TITLE
Fixes #25479 - Ignore edit permission on timestamp bump

### DIFF
--- a/app/models/foreman_virt_who_configure/config.rb
+++ b/app/models/foreman_virt_who_configure/config.rb
@@ -206,7 +206,7 @@ module ForemanVirtWhoConfigure
     def virt_who_touch!
       self.last_report_at = DateTime.now.utc
       self.out_of_date_at = self.last_report_at + self.interval.minutes
-      self.save!
+      self.class.skip_permission_check { self.save! }
     end
 
     def status


### PR DESCRIPTION
@tstrachota could you take a quick look pls? the problem was introduced with enforcing permission check on save, reporting user does not have edit_virt_who_config permission, but it shouldn't be required for timestamp update on receive report, so we should skip the check