### PR TITLE
Fixes #29057 - Hosts filtering missing from kubevirt configs

### DIFF
--- a/app/models/foreman_virt_who_configure/output_generator.rb
+++ b/app/models/foreman_virt_who_configure/output_generator.rb
@@ -99,7 +99,7 @@ if verify_minimal_version; then
 type=#{type}
 hypervisor_id=#{hypervisor_id}
 owner=#{owner}
-env=Library#{connection_details}
+env=Library#{connection_details}#{filtering}
 rhsm_hostname=#{satellite_url}
 rhsm_username=#{service_user_username}
 rhsm_encrypted_password=$user_password
@@ -142,7 +142,7 @@ EOS
       else
         "\nserver=#{cr_server}
 username=#{cr_username}
-encrypted_password=$cr_password#{filtering}"
+encrypted_password=$cr_password"
       end
     end
 


### PR DESCRIPTION
```
Run options: --seed 58438                                                      
                                                                               
# Running:                                                                     
                                                                               
.............................................
                                                                               
Finished in 18.631107s, 2.4153 runs/s, 9.7149 assertions/s.             
                                       
45 runs, 181 assertions, 0 failures, 0 errors, 0 skips
```