### PR TITLE
Refs #26320 - http and https proxy both for virt-who config script

### DIFF
--- a/app/assets/javascripts/foreman_virt_who_configure/config_new.js
+++ b/app/assets/javascripts/foreman_virt_who_configure/config_new.js
@@ -1,0 +1,9 @@
+function virt_who_enable_https_proxy(item) {
+  const checked = $(item).is(':checked');
+
+  if( checked ){
+    $("label[for='proxy']").text("HTTPS Proxy");
+  } else {
+    $("label[for='proxy']").text("HTTP Proxy");
+  }
+}

--- a/app/controllers/foreman_virt_who_configure/api/v2/configs_controller.rb
+++ b/app/controllers/foreman_virt_who_configure/api/v2/configs_controller.rb
@@ -52,6 +52,7 @@ module ForemanVirtWhoConfigure
             param :hypervisor_password, String, :desc => N_("Hypervisor password, required for all hypervisor types except for libvirt"), :required => false
             param :satellite_url, String, :desc => N_("Satellite server FQDN"), :required => true
             param :debug, :bool, :desc => N_("Enable debugging output")
+            param :proxy_type, String, :desc => N_("Enable HTTPS proxy"), :required => false
             param :proxy, String, :desc => N_('HTTP proxy that should be used for communication between the server on which virt-who is running and the hypervisors and virtualization managers.'), :required => false
             param :no_proxy, String, :desc => N_("Ignore proxy. A comma-separated list of hostnames or domains or ip addresses to ignore proxy settings for. Optionally this may be set to * to bypass proxy settings for all hostnames domains or ip addresses.")
             param :organization_id, Integer, :required => true, :desc => N_("Organization of the virt-who configuration") if ::SETTINGS[:organizations_enabled]

--- a/app/models/foreman_virt_who_configure/config.rb
+++ b/app/models/foreman_virt_who_configure/config.rb
@@ -3,7 +3,7 @@ module ForemanVirtWhoConfigure
     PERMITTED_PARAMS = [
       :interval, :organization_id, :compute_resource_id, :whitelist, :blacklist, :hypervisor_id,
       :hypervisor_type, :hypervisor_server, :hypervisor_username, :hypervisor_password, :debug,
-      :satellite_url, :proxy, :no_proxy, :name,
+      :satellite_url, :proxy, :no_proxy, :name, :proxy_type,
       # API parameter filtering_mode gets translated to listing_mode in the controller
       # We keep both params permitted for compatibility with 1.11
       :listing_mode, :filtering_mode, :filter_host_parents, :exclude_host_parents, :kubeconfig_path
@@ -67,6 +67,8 @@ module ForemanVirtWhoConfigure
         :out_of_date => N_('The virt-who report has not arrived within the interval, which indicates there was no change on hypervisor')
       }
     )
+
+    enum proxy_type: [:http, :https]
 
     include Encryptable
     encrypts :hypervisor_password
@@ -245,6 +247,10 @@ module ForemanVirtWhoConfigure
 
     def status_description
       _(STATUS_DESCRIPTIONS[status])
+    end
+
+    def proxy_label
+      self.https? ? "HTTPS Proxy" : "HTTP Proxy"
     end
 
     private

--- a/app/models/foreman_virt_who_configure/output_generator.rb
+++ b/app/models/foreman_virt_who_configure/output_generator.rb
@@ -266,7 +266,7 @@ encrypted_password=$cr_password"
 
     def proxy_strings
       output = ''
-      output << "\nhttp_proxy=#{sanitize_proxy(proxy)}" if proxy.present?
+      output << "\n#{proxy_type}=#{sanitize_proxy(proxy)}" if proxy.present?
       output << "\nNO_PROXY=#{sanitize_proxy(no_proxy)}" if no_proxy.present?
       output << "\nNO_PROXY=*" if !proxy.present? && !no_proxy.present?
       output
@@ -274,6 +274,10 @@ encrypted_password=$cr_password"
 
     def sanitize(string)
       string.tr("\r\n", '').strip.chomp(",")
+    end
+
+    def proxy_type
+      config.https? ? "https_proxy" : "http_proxy"
     end
   end
 end

--- a/app/views/foreman_virt_who_configure/configs/show.html.erb
+++ b/app/views/foreman_virt_who_configure/configs/show.html.erb
@@ -48,7 +48,8 @@
             <%= config_attribute :exclude_host_parents, @config.exclude_host_parents if @config.exclude_host_parents.present? %>
           <% end %>
           <%= config_attribute :debug, checked_icon(@config.debug), _('Enable debugging output?') %>
-          <%= config_attribute :proxy, @config.proxy, _('HTTP Proxy') if @config.proxy.present? %>
+          <%= config_attribute :proxy_type, checked_icon(@config.https?), _('Enable HTTPS proxy?') if @config.proxy.present? %>
+          <%= config_attribute :proxy, @config.proxy, _(@config.proxy_label) if @config.proxy.present? %>
           <%= config_attribute :no_proxy, @config.no_proxy, _('Ignore Proxy') if @config.no_proxy.present? %>
           <%= config_attribute :kubeconfig_path, @config.kubeconfig_path if @config.hypervisor_type == 'kubevirt' %>
         </div>

--- a/app/views/foreman_virt_who_configure/configs/steps/_connection_form.erb
+++ b/app/views/foreman_virt_who_configure/configs/steps/_connection_form.erb
@@ -1,3 +1,4 @@
+<% javascript 'foreman_virt_who_configure/config_new' %>
 <div id="config_connection">
   <%= text_f f, :satellite_url, inline_help_popover(_('Satellite Server’s fully-qualified host name, for example: satellite.example.com')).merge(:label => _('Satellite server FQDN')) %>
   <%= select_f f, :hypervisor_id, ForemanVirtWhoConfigure::Config::HYPERVISOR_IDS, :to_s, :to_s, {}, { :label => _('Hypervisor ID') }.merge(
@@ -18,7 +19,13 @@
   <%= textarea_f f, :exclude_host_parents, inline_help_popover(_('Hosts which parent (usually ComputeResource) name is specified in comma-separated list in this option will <b>NOT</b> be reported. Wildcards and regular expressions are supported, multiple records must be separated by comma. Put the value into the double-quotes if it contains special characters like comma. All new line characters will be removed in resulting configuration file, white spaces are removed from beginning and end.')).merge(:label => _('Exclude host parents')) %>
 
   <%= checkbox_f f, :debug, { :label => _('Enable debugging output') }.merge(inline_help_popover(_("Different debug value can't be set per hypervisor, therefore it will affect all other deployed configurations on the host on which this configuration will be deployed."))) %>
-  <%= text_f f, :proxy, inline_help_popover(_('HTTP proxy that should be used for communication between the server on which virt-who is running and the hypervisors and virtualization managers. Leave this blank if no proxy is used.')).merge(:label => _('HTTP proxy')) %>
+
+  <%= checkbox_f f, :proxy_type,
+      { :label => _('Enable HTTPS proxy'), :onchange => "virt_who_enable_https_proxy(this)" }.merge(inline_help_popover(_("Enable communication with HTTPS proxy"))),
+      ForemanVirtWhoConfigure::Config.proxy_types.keys[ForemanVirtWhoConfigure::Config.proxy_types[:https]],
+      ForemanVirtWhoConfigure::Config.proxy_types.keys[ForemanVirtWhoConfigure::Config.proxy_types[:http]] %>
+
+  <%= text_f f, :proxy, inline_help_popover(_('HTTP/HTTPS proxy that should be used for communication between the server on which virt-who is running and the hypervisors and virtualization managers. Leave this blank if no proxy is used.')).merge(:label => @config.proxy_label) %>
   <%= text_f f, :no_proxy, inline_help_popover(_('A comma-separated list of hostnames or domains or ip addresses to ignore proxy settings for. Optionally this may be set to <code>*</code> to bypass proxy settings for all hostnames domains or ip addresses.')).merge(:label => _('Ignore proxy')) %>
   <%= text_f f, :kubeconfig_path, inline_help_popover(_('Configuration file containing details about how to connect to the cluster and authentication details')).merge(:label => _('Path to kubeconfig file')) %>
 </div>

--- a/db/migrate/20200617161121_add_proxy_type_to_config.rb
+++ b/db/migrate/20200617161121_add_proxy_type_to_config.rb
@@ -1,0 +1,5 @@
+class AddProxyTypeToConfig < ActiveRecord::Migration[6.0]
+  def change
+    add_column :foreman_virt_who_configure_configs, :proxy_type, :integer, :null => false, :default => 0
+  end
+end

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -16,6 +16,12 @@ module ForemanVirtWhoConfigure
       test 'config creates service user upon creation' do
         assert existing_config.service_user
         assert_equal "virt_who_reporter_#{config.id}", existing_config.service_user.username
+        assert_equal "http", existing_config.proxy_type
+      end
+
+      test 'creates https proxy config' do
+        existing_config.https!
+        assert_equal "https", existing_config.proxy_type
       end
 
       test 'config creates hidden user' do


### PR DESCRIPTION
What was done:

When create configuration by virt-who configure plugin, no options for selecting to HTTP Proxy, it just uses the default "http_proxy".
"http_proxy" and "https_proxy" options are provided.