### PR TITLE
Refs #26320 - http and https proxy both for virt-who config script

### DIFF
--- a/app/models/foreman_virt_who_configure/config.rb
+++ b/app/models/foreman_virt_who_configure/config.rb
@@ -3,7 +3,7 @@ module ForemanVirtWhoConfigure
     PERMITTED_PARAMS = [
       :interval, :organization_id, :compute_resource_id, :whitelist, :blacklist, :hypervisor_id,
       :hypervisor_type, :hypervisor_server, :hypervisor_username, :hypervisor_password, :debug,
-      :satellite_url, :proxy, :no_proxy, :name,
+      :satellite_url, :http_proxy_id, :no_proxy, :name,
       # API parameter filtering_mode gets translated to listing_mode in the controller
       # We keep both params permitted for compatibility with 1.11
       :listing_mode, :filtering_mode, :filter_host_parents, :exclude_host_parents, :kubeconfig_path
@@ -73,6 +73,7 @@ module ForemanVirtWhoConfigure
 
     belongs_to :compute_resource
     belongs_to :organization
+    belongs_to :http_proxy
 
     # service user used by virt-who to report back
     belongs_to :service_user

--- a/app/models/foreman_virt_who_configure/output_generator.rb
+++ b/app/models/foreman_virt_who_configure/output_generator.rb
@@ -253,7 +253,7 @@ encrypted_password=$cr_password"
     end
 
     def proxy
-      config.proxy
+      config.http_proxy
     end
 
     def no_proxy
@@ -264,9 +264,13 @@ encrypted_password=$cr_password"
       sanitize(string)
     end
 
+    def proxy_type
+      "#{URI(proxy.url).scheme}_proxy"
+    end
+
     def proxy_strings
       output = ''
-      output << "\nhttp_proxy=#{sanitize_proxy(proxy)}" if proxy.present?
+      output << "\n#{proxy_type}=#{sanitize_proxy(proxy.full_url)}" if proxy.present?
       output << "\nNO_PROXY=#{sanitize_proxy(no_proxy)}" if no_proxy.present?
       output << "\nNO_PROXY=*" if !proxy.present? && !no_proxy.present?
       output

--- a/app/views/foreman_virt_who_configure/configs/show.html.erb
+++ b/app/views/foreman_virt_who_configure/configs/show.html.erb
@@ -48,7 +48,7 @@
             <%= config_attribute :exclude_host_parents, @config.exclude_host_parents if @config.exclude_host_parents.present? %>
           <% end %>
           <%= config_attribute :debug, checked_icon(@config.debug), _('Enable debugging output?') %>
-          <%= config_attribute :proxy, @config.proxy, _('HTTP Proxy') if @config.proxy.present? %>
+          <%= config_attribute :http_proxy_id, @config.http_proxy.full_url, _('HTTP Proxy') if @config.http_proxy.present? %>
           <%= config_attribute :no_proxy, @config.no_proxy, _('Ignore Proxy') if @config.no_proxy.present? %>
           <%= config_attribute :kubeconfig_path, @config.kubeconfig_path if @config.hypervisor_type == 'kubevirt' %>
         </div>

--- a/app/views/foreman_virt_who_configure/configs/steps/_connection_form.erb
+++ b/app/views/foreman_virt_who_configure/configs/steps/_connection_form.erb
@@ -18,7 +18,8 @@
   <%= textarea_f f, :exclude_host_parents, inline_help_popover(_('Hosts which parent (usually ComputeResource) name is specified in comma-separated list in this option will <b>NOT</b> be reported. Wildcards and regular expressions are supported, multiple records must be separated by comma. Put the value into the double-quotes if it contains special characters like comma. All new line characters will be removed in resulting configuration file, white spaces are removed from beginning and end.')).merge(:label => _('Exclude host parents')) %>
 
   <%= checkbox_f f, :debug, { :label => _('Enable debugging output') }.merge(inline_help_popover(_("Different debug value can't be set per hypervisor, therefore it will affect all other deployed configurations on the host on which this configuration will be deployed."))) %>
-  <%= text_f f, :proxy, inline_help_popover(_('HTTP proxy that should be used for communication between the server on which virt-who is running and the hypervisors and virtualization managers. Leave this blank if no proxy is used.')).merge(:label => _('HTTP proxy')) %>
+  <%= select_f f, :http_proxy_id, HttpProxy.all, :id, :full_url, {:include_blank => true}, { :label => _('HTTP Proxy') }.merge(
+        inline_help_popover(_('HTTP proxy that should be used for communication between the server on which virt-who is running and the hypervisors and virtualization managers. Leave this blank if no proxy is used.').html_safe)) %>
   <%= text_f f, :no_proxy, inline_help_popover(_('A comma-separated list of hostnames or domains or ip addresses to ignore proxy settings for. Optionally this may be set to <code>*</code> to bypass proxy settings for all hostnames domains or ip addresses.')).merge(:label => _('Ignore proxy')) %>
   <%= text_f f, :kubeconfig_path, inline_help_popover(_('Configuration file containing details about how to connect to the cluster and authentication details')).merge(:label => _('Path to kubeconfig file')) %>
 </div>

--- a/db/migrate/20200728054557_refer_config_proxy_to_http_proxy.rb
+++ b/db/migrate/20200728054557_refer_config_proxy_to_http_proxy.rb
@@ -1,0 +1,74 @@
+class ReferConfigProxyToHttpProxy < ActiveRecord::Migration[6.0]
+  def up
+    add_column :foreman_virt_who_configure_configs, :http_proxy_id, :integer
+
+    if User.where(login: User::ANONYMOUS_ADMIN).exists?
+      User.as_anonymous_admin do
+        http_proxies = HttpProxy.all
+        ::ForemanVirtWhoConfigure::Config.find_each do |config|
+          if config.proxy.present?
+            migrate_config(http_proxies, config)
+          end
+        end
+      end
+    end
+
+    remove_column :foreman_virt_who_configure_configs, :proxy
+  end
+
+  def down
+    add_column :foreman_virt_who_configure_configs, :proxy, :string
+
+    if User.where(login: User::ANONYMOUS_ADMIN).exists?
+      User.as_anonymous_admin do
+        ::ForemanVirtWhoConfigure::Config.find_each do |config|
+          if config.http_proxy_id.present?
+            config.proxy = config.http_proxy.full_url
+            config.save!
+          end
+        end
+      end
+    end
+
+    remove_column :foreman_virt_who_configure_configs, :http_proxy_id
+  end
+
+  private
+
+  def migrate_config(http_proxies, config)
+    http_proxy = http_proxies.find { |proxy| proxy.full_url == proxy_uri(config.proxy).to_s }
+
+    if http_proxy.present?
+      config.http_proxy = http_proxy
+    else
+      http_proxy = build_http_proxy(config.proxy)
+      if http_proxy.save
+        config.http_proxy_id = http_proxy.id
+      end
+    end
+
+    config.save!
+  rescue URI::InvalidURIError
+    Rails.logger.debug "Config with id #{config.id} has not valid proxy #{config.proxy}"
+  end
+
+  def proxy_uri(config_proxy)
+    uri = URI(config_proxy)
+    unless ['http', 'https'].include? uri.scheme
+      config_proxy = "http://#{config_proxy}"
+      uri = URI(config_proxy)
+    end
+    uri
+  end
+
+  def build_http_proxy(proxy_url)
+    uri = proxy_uri(proxy_url)
+    url = if uri.port
+            "#{uri.scheme}://#{uri.host}:#{uri.port.to_s}"
+          else
+            "#{uri.scheme}://#{uri.host}"
+          end
+
+    HttpProxy.new(name: "virt_who_#{uri.host}", url: url, username: uri.user, password: uri.password)
+  end
+end

--- a/test/functional/api/v2/configs_controller_test.rb
+++ b/test/functional/api/v2/configs_controller_test.rb
@@ -2,6 +2,7 @@ require 'test_plugin_helper'
 
 class ForemanVirtWhoConfigure::Api::V2::ConfigsControllerTest < ActionController::TestCase
   setup do
+    @http_proxy = FactoryBot.create(:http_proxy, name: "test", url: "http://test.com")
     @new_config = FactoryBot.create(:virt_who_config,
                                  :name => 'my vmware',
                                  :interval => 120,
@@ -13,7 +14,7 @@ class ForemanVirtWhoConfigure::Api::V2::ConfigsControllerTest < ActionController
                                  :hypervisor_username => "root",
                                  :debug => false,
                                  :satellite_url => "foreman.example.com",
-                                 :proxy => 'proxy.example.com',
+                                 :http_proxy_id => @http_proxy.id,
                                  :no_proxy => nil
     )
 
@@ -41,7 +42,6 @@ class ForemanVirtWhoConfigure::Api::V2::ConfigsControllerTest < ActionController
     refute result_config['debug']
     assert_not_nil result_config['debug']
     assert_equal 'foreman.example.com', result_config['satellite_url']
-    assert_equal 'proxy.example.com', result_config['proxy']
     assert_nil result_config['no_proxy']
     assert_equal 'unknown', result_config['status']
     assert_nil result_config['last_report_at']
@@ -74,11 +74,11 @@ class ForemanVirtWhoConfigure::Api::V2::ConfigsControllerTest < ActionController
     refute response['debug']
     assert_not_nil response['debug']
     assert_equal 'foreman.example.com', response['satellite_url']
-    assert_equal 'proxy.example.com', response['proxy']
     assert_nil response['no_proxy']
     assert_equal 'unknown', response['status']
     assert_nil response['last_report_at']
     assert_nil response['out_of_date_at']
+    assert_equal @http_proxy.id, ForemanVirtWhoConfigure::Config.find(response['id']).http_proxy_id
 
     assert_response :success
   end

--- a/test/unit/migrate_config_proxy_to_http_proxy.rb
+++ b/test/unit/migrate_config_proxy_to_http_proxy.rb
@@ -1,0 +1,158 @@
+require 'test_plugin_helper'
+require ForemanVirtWhoConfigure::Engine.root.join('db', 'migrate', '20200728054557_refer_config_proxy_to_http_proxy.rb')
+
+module ForemanVirtWhoConfigure
+  class MigrateConfigProxyToHttpProxy < ActiveSupport::TestCase
+    let(:migration) { klass.new }
+
+    def migration_has_been_run?(version)
+      ActiveRecord::SchemaMigration.where(version: version).exists?
+    end
+
+    describe "up" do
+      let(:config) { FactoryBot.build(:virt_who_config) }
+
+      before do
+        if migration_has_been_run?('20200728054557')
+          migration.down
+        end
+
+        HttpProxy.delete_all
+      end
+
+      it "should create Http Proxy if already not exist" do
+        config.proxy = "test.example.com"
+        config.save!
+
+        assert_difference('HttpProxy.count', 1) do
+          migration.up
+        end
+
+        assert_equal "http://test.example.com", created_http_proxy.full_url
+      end
+
+      it "should create Http Proxy with user and password if already not exist" do
+        config.proxy = "http://user:password@test.example.com"
+        config.save!
+
+        assert_difference('HttpProxy.count', 1) do
+          migration.up
+        end
+
+        assert_equal "http://user:password@test.example.com", created_http_proxy.full_url
+        assert_equal "user", created_http_proxy.username
+        assert_equal "password", created_http_proxy.password
+      end
+
+      it "should not create Http Proxy for invalid config proxy if already not exist" do
+        config.proxy = "test.example.com:5000"
+        config.save!
+
+        assert_difference('HttpProxy.count', 1) do
+          migration.up
+        end
+
+        assert_equal "http://test.example.com:5000", created_http_proxy.full_url
+      end
+
+      it "should create Http Proxy with port for config proxy if already not exist" do
+        config.proxy = "https://test.example.com:5000"
+        config.save!
+
+        assert_difference('HttpProxy.count', 1) do
+          migration.up
+        end
+
+        assert_equal "https://test.example.com:5000", created_http_proxy.full_url
+      end
+
+      it "should refer to existed Http Proxy" do
+        http_proxy = FactoryBot.create(:http_proxy, name: "test", url: "http://test.com")
+        config.proxy = "http://test.com"
+        config.save!
+
+        assert_difference('HttpProxy.count', 0) do
+          migration.up
+        end
+
+        assert_equal updated_config.http_proxy_id, http_proxy.id
+      end
+
+      it "should refer to existed IP address http proxy" do
+        http_proxy = FactoryBot.create(:http_proxy, name: "test", url: "http://212.212.10.23")
+        config.proxy = "212.212.10.23"
+        config.save!
+
+        assert_difference('HttpProxy.count', 0) do
+          migration.up
+        end
+
+        assert_equal updated_config.http_proxy_id, http_proxy.id
+      end
+
+      it "should create new http proxy if user and password is present" do
+        http_proxy = FactoryBot.create(:http_proxy, name: "test", url: "http://proxy.example.com", username: "admin", password: "pass")
+        config.proxy = "http://proxy.example.com"
+        config.save!
+
+        assert_difference('HttpProxy.count', 1) do
+          migration.up
+        end
+
+        assert_not_equal updated_config.http_proxy_id, http_proxy.id
+        assert_equal updated_config.http_proxy_id, created_http_proxy.id
+        assert_equal "http://proxy.example.com", created_http_proxy.full_url
+      end
+
+      it "refer to http proxy if user and password is present" do
+        http_proxy = FactoryBot.create(:http_proxy, name: "test", url: "http://proxy.example.com", username: "admin", password: "pass")
+        config.proxy = "http://admin:pass@proxy.example.com"
+        config.save!
+
+        assert_difference('HttpProxy.count', 0) do
+          migration.up
+        end
+
+        assert_equal updated_config.http_proxy_id, http_proxy.id
+      end
+
+      it "should create new http proxy if port is there" do
+        http_proxy = FactoryBot.create(:http_proxy, name: "test", url: "http://proxy.example.com:5000")
+        config.proxy = "http://proxy.example.com"
+        config.save!
+
+        assert_difference('HttpProxy.count', 1) do
+          migration.up
+        end
+
+        assert_not_equal updated_config.http_proxy_id, http_proxy.id
+        assert_equal updated_config.http_proxy_id, created_http_proxy.id
+        assert_equal "http://proxy.example.com", created_http_proxy.full_url
+      end
+
+      it "should refer to existed http proxy if port is there and config proxy has also same port" do
+        http_proxy = FactoryBot.create(:http_proxy, name: "test", url: "http://proxy.example.com:5000")
+        config.proxy = "http://proxy.example.com:5000"
+        config.save!
+
+        assert_difference('HttpProxy.count', 0) do
+          migration.up
+        end
+
+        assert_equal updated_config.http_proxy_id, http_proxy.id
+      end
+    end
+
+    def klass
+      ReferConfigProxyToHttpProxy
+    end
+
+    def updated_config
+      ::ForemanVirtWhoConfigure::Config.last
+    end
+
+    def created_http_proxy
+      HttpProxy.order(:id).last
+    end
+  end
+end

--- a/test/unit/output_generator_test.rb
+++ b/test/unit/output_generator_test.rb
@@ -57,15 +57,16 @@ module ForemanVirtWhoConfigure
 
     describe 'proxy attributes' do
       test 'it does not set any proxy attributes by default and set no_proxy to * to bypass sub-man proxy' do
-        assert_nil config.proxy
+        assert_nil config.http_proxy
         assert_nil config.no_proxy
         assert_not_includes output, 'http_proxy'
         assert_includes output, 'NO_PROXY=*'
       end
 
       test 'it configures proxy when set' do
-        config.proxy = 'http://proxy.com'
-        assert_includes output, 'http_proxy=http://proxy.com'
+        http_proxy = HttpProxy.create!(name: "test", url: "http://test.com")
+        config.http_proxy = http_proxy
+        assert_includes output, 'http_proxy=http://test.com'
       end
 
       test 'it configures no_proxy when set' do
@@ -74,24 +75,29 @@ module ForemanVirtWhoConfigure
       end
 
       test 'proxy_strings prints both proxy and no proxy if present' do
-        config.proxy = 'a'
+        http_proxy = HttpProxy.create!(name: "test", url: "http://test.com")
+        config.http_proxy = http_proxy
         config.no_proxy = 'b'
-        assert_includes generator.proxy_strings, "\nhttp_proxy=a"
+        assert_includes generator.proxy_strings, "\nhttp_proxy=http://test.com"
         assert_includes generator.proxy_strings, "\NO_PROXY=b"
       end
 
       test 'proxy_strings ignores empty string values' do
-        config.proxy = ''
+        config.http_proxy = nil
         config.no_proxy = ''
         assert_not_includes generator.proxy_strings, 'http_proxy'
         assert_includes generator.proxy_strings, 'NO_PROXY=*'
       end
 
       test 'proxy_strings removes any new line chars' do
-        config.proxy = "\na\nb\nc\n"
         config.no_proxy = "\nx\ny\nz"
-        assert_includes generator.proxy_strings, "\nhttp_proxy=abc"
         assert_includes generator.proxy_strings, "\NO_PROXY=xyz"
+      end
+
+      test 'it configures https proxy when https proxy is set' do
+        http_proxy = HttpProxy.create!(name: "test", url: "https://test.com")
+        config.http_proxy = http_proxy
+        assert_includes output, 'https_proxy=https://test.com'
       end
     end
 


### PR DESCRIPTION
What was done:

To create new `virt-who-config`, This change includes drop down for selecting the proxy and on the basis of proxy, the proxy_type of the deploy script will get decided.