### PR TITLE
Fixes #31325 - Breadcrumbs bar text and icon misaligned

### DIFF
--- a/app/views/foreman_virt_who_configure/configs/edit.html.erb
+++ b/app/views/foreman_virt_who_configure/configs/edit.html.erb
@@ -2,12 +2,13 @@
 
 <%= breadcrumbs(:resource_url => foreman_virt_who_configure_api_configs_path,
                 :items => [
-                    {:caption => _('Configurations'),
-                     :url => url_for(foreman_virt_who_configure_configs_path)
-                    },
-                    {:caption => _('Edit') + ' ' + @config.name,
-                     :url => (edit_foreman_virt_who_configure_config_path(@config) if authorized_for(hash_for_edit_foreman_virt_who_configure_config_path(@config)))
-                    }
+                  {
+                    :caption => _('Virt-who Configurations'),
+                    :url => foreman_virt_who_configure_configs_path
+                  },
+                  {
+                    :caption => _('Edit') + ' ' + @config.name
+                  }
                 ]
     ) %>
 

--- a/app/views/foreman_virt_who_configure/configs/show.html.erb
+++ b/app/views/foreman_virt_who_configure/configs/show.html.erb
@@ -8,12 +8,13 @@
 
 <%= breadcrumbs(:resource_url => foreman_virt_who_configure_api_configs_path,
                 :items => [
-                    {:caption => _('Configurations'),
-                     :url => url_for(foreman_virt_who_configure_configs_path)
-                    },
-                    {:caption => @config.name,
-                     :url => (edit_foreman_virt_who_configure_config_path(@config) if authorized_for(hash_for_edit_foreman_virt_who_configure_config_path(@config)))
-                    }
+                  {
+                    :caption => _('Virt-who Configurations'),
+                    :url => foreman_virt_who_configure_configs_path
+                  },
+                  {
+                    :caption => @config.name
+                  }
                 ]
     ) %>
 


### PR DESCRIPTION
This was broken because the final item is not supposed to have a URL. Seems like it regressed when the component was migrated to react. 