### PR TITLE
Fixes 31467 - Add back proxy info to api output with show

### DIFF
--- a/app/controllers/foreman_virt_who_configure/api/v2/configs_controller.rb
+++ b/app/controllers/foreman_virt_who_configure/api/v2/configs_controller.rb
@@ -52,7 +52,7 @@ module ForemanVirtWhoConfigure
             param :hypervisor_password, String, :desc => N_("Hypervisor password, required for all hypervisor types except for libvirt"), :required => false
             param :satellite_url, String, :desc => N_("Satellite server FQDN"), :required => true
             param :debug, :bool, :desc => N_("Enable debugging output")
-            param :proxy, String, :desc => N_('HTTP proxy that should be used for communication between the server on which virt-who is running and the hypervisors and virtualization managers.'), :required => false
+            param :http_proxy_id, Integer, :desc => N_('HTTP proxy that should be used for communication between the server on which virt-who is running and the hypervisors and virtualization managers.')
             param :no_proxy, String, :desc => N_("Ignore proxy. A comma-separated list of hostnames or domains or ip addresses to ignore proxy settings for. Optionally this may be set to * to bypass proxy settings for all hostnames domains or ip addresses.")
             param :organization_id, Integer, :required => true, :desc => N_("Organization of the virt-who configuration") if ::SETTINGS[:organizations_enabled]
           end

--- a/app/views/foreman_virt_who_configure/api/v2/configs/main.json.rabl
+++ b/app/views/foreman_virt_who_configure/api/v2/configs/main.json.rabl
@@ -2,8 +2,17 @@ object @config
 
 extends "foreman_virt_who_configure/api/v2/configs/base"
 
+glue :http_proxy do
+  attributes :url => :proxy
+end
+
 attributes :name, :interval, :organization_id, :whitelist, :blacklist, :hypervisor_id,
            :hypervisor_type, :hypervisor_server, :hypervisor_username, :debug,
            :satellite_url, :proxy, :no_proxy, :status, :last_report_at, :out_of_date_at,
            :filter_host_parents, :exclude_host_parents
+
+child :http_proxy do
+  attributes :id, :name, :url
+end
+
 attributes :listing_mode => :filtering_mode

--- a/db/migrate/20201211160234_add_foreign_key_proxy_id.rb
+++ b/db/migrate/20201211160234_add_foreign_key_proxy_id.rb
@@ -1,0 +1,5 @@
+class AddForeignKeyProxyId < ActiveRecord::Migration[6.0]
+  def change
+    add_foreign_key :foreman_virt_who_configure_configs, :http_proxies, :column => :http_proxy_id
+  end
+end

--- a/test/functional/api/v2/configs_controller_test.rb
+++ b/test/functional/api/v2/configs_controller_test.rb
@@ -78,7 +78,8 @@ class ForemanVirtWhoConfigure::Api::V2::ConfigsControllerTest < ActionController
     assert_equal 'unknown', response['status']
     assert_nil response['last_report_at']
     assert_nil response['out_of_date_at']
-    assert_equal @http_proxy.id, ForemanVirtWhoConfigure::Config.find(response['id']).http_proxy_id
+    assert_equal @http_proxy.id, response['http_proxy']['id']
+    assert_equal @http_proxy.url, response['proxy']
 
     assert_response :success
   end
@@ -140,6 +141,7 @@ class ForemanVirtWhoConfigure::Api::V2::ConfigsControllerTest < ActionController
                                                             :hypervisor_password => "password",
                                                             :debug => true,
                                                             :satellite_url => "foreman.example.com",
+                                                            :http_proxy_id => @http_proxy.id,
                                                             :organization_id => org.id }
     }, :session => set_session_user
 
@@ -158,6 +160,7 @@ class ForemanVirtWhoConfigure::Api::V2::ConfigsControllerTest < ActionController
     assert_equal 'password', new_config.hypervisor_password
     assert_equal true, new_config.debug
     assert_equal 'foreman.example.com', new_config.satellite_url
+    assert_equal @http_proxy.id, response['http_proxy']['id']
   end
 
   test "should update the config" do


### PR DESCRIPTION
Requires: https://github.com/theforeman/hammer-cli-foreman-virt-who-configure/pull/11