### PR TITLE
Fixes #32201 - Expose kubeconfig_path in API response

### DIFF
--- a/app/views/foreman_virt_who_configure/api/v2/configs/main.json.rabl
+++ b/app/views/foreman_virt_who_configure/api/v2/configs/main.json.rabl
@@ -9,7 +9,7 @@ end
 attributes :name, :interval, :organization_id, :whitelist, :blacklist, :hypervisor_id,
            :hypervisor_type, :hypervisor_server, :hypervisor_username, :debug,
            :satellite_url, :proxy, :no_proxy, :status, :last_report_at, :out_of_date_at,
-           :filter_host_parents, :exclude_host_parents
+           :filter_host_parents, :exclude_host_parents, :kubeconfig_path
 
 child :http_proxy do
   attributes :id, :name, :url


### PR DESCRIPTION
Hammer PR to add the field:

https://github.com/theforeman/hammer-cli-foreman-virt-who-configure/pull/13

Output of results:

```bash
[vagrant@hammer ~]$ hammer virt-who-config show --id 1
General information:
    Id:                  1
    Name:                Test
    Hypervisor type:     kubevirt
    Hypervisor server:
    Hypervisor username:
    Configuration file:  /tmp/food
    Status:              No Report Yet
Schedule:
    Interval:       every 4 hours
    Last Report At:
Connection:
    Satellite server:     devel.croberts.lan
    Hypervisor ID:        hostname
    Filtering:            Unlimited
    Filter host parents:
    Exclude host parents:
    Debug mode:           no
    Ignore proxy:
```