### PR TITLE
Fixes #32240 - Update virt-who config file path

### DIFF
--- a/app/helpers/foreman_virt_who_configure/configs_helper.rb
+++ b/app/helpers/foreman_virt_who_configure/configs_helper.rb
@@ -14,7 +14,7 @@ module ForemanVirtWhoConfigure
 
     def hypervisor_username_help_data
       @hypervisor_username_help_data ||= {
-        'esx' => _('Account name by which virt-who is to connect to the hypervisor, in the format <code>domain_name\account_name</code>. Note that only a single backslash separates the values for domain_name and account_name. If you are using a domain account, and the global configuration file <code>/etc/sysconfig/virt-who</code>, then <b>two</b> backslashes are required. For further details, see <a href="https://access.redhat.com/solutions/1270223">Red Hat Knowledgebase solution How to use a windows domain account with virt-who</a> for more information.'),
+        'esx' => _('Account name by which virt-who is to connect to the hypervisor, in the format <code>domain_name\account_name</code>. Note that only a single backslash separates the values for domain_name and account_name. If you are using a domain account, and the global configuration file <code>/etc/virt-who.conf</code>, then <b>two</b> backslashes are required. For further details, see <a href="https://access.redhat.com/solutions/1270223">Red Hat Knowledgebase solution How to use a windows domain account with virt-who</a> for more information.'),
         'rhevm' => _('Account name by which virt-who is to connect to the Red Hat Enterprise Virtualization Manager instance. The username option requires input in the format username@domain.'),
         # 'vdsm' => '',
         'hyperv' => _('Account name by which virt-who is to connect to the hypervisor. By default this is <code>Administrator</code>. To use an alternate account, create a user account and assign that account to the following groups (Windows 2012 Server): Hyper-V Administrators and Remote Management Users.'),

--- a/test/unit/output_generator_test.rb
+++ b/test/unit/output_generator_test.rb
@@ -60,7 +60,7 @@ module ForemanVirtWhoConfigure
         assert_nil config.http_proxy
         assert_nil config.no_proxy
         assert_not_includes output, 'http_proxy'
-        assert_includes output, 'NO_PROXY=*'
+        assert_includes output, 'no_proxy=*'
       end
 
       test 'it configures proxy when set' do
@@ -71,7 +71,7 @@ module ForemanVirtWhoConfigure
 
       test 'it configures no_proxy when set' do
         config.no_proxy = '*'
-        assert_includes output, 'NO_PROXY=*'
+        assert_includes output, 'no_proxy=*'
       end
 
       test 'proxy_strings prints both proxy and no proxy if present' do
@@ -79,19 +79,19 @@ module ForemanVirtWhoConfigure
         config.http_proxy = http_proxy
         config.no_proxy = 'b'
         assert_includes generator.proxy_strings, "\nhttp_proxy=http://test.com"
-        assert_includes generator.proxy_strings, "\NO_PROXY=b"
+        assert_includes generator.proxy_strings, "\nno_proxy=b"
       end
 
       test 'proxy_strings ignores empty string values' do
         config.http_proxy = nil
         config.no_proxy = ''
         assert_not_includes generator.proxy_strings, 'http_proxy'
-        assert_includes generator.proxy_strings, 'NO_PROXY=*'
+        assert_includes generator.proxy_strings, 'no_proxy=*'
       end
 
       test 'proxy_strings removes any new line chars' do
         config.no_proxy = "\nx\ny\nz"
-        assert_includes generator.proxy_strings, "\NO_PROXY=xyz"
+        assert_includes generator.proxy_strings, "\nno_proxy=xyz"
       end
 
       test 'it configures https proxy when https proxy is set' do


### PR DESCRIPTION
## Testing steps

Create a virt-who config and deploy it. Notice before the patch you will see this file:

`/etc/sysconfig/virt-who`

Apply the patch and create a new config and deploy it.

You will see the `/etc/sysconfig/virt-who` gone and the new file `/etc/virt-who.conf` created. 

## New Deployments

Screen shot of script using new config file and removing the old one:

https://nimb.ws/JVqc86

Output after hammer command has been run to deploy the config:
```bash
[root@dhcp-8-30-209 ~]# cat /etc/virt-who.conf
### This configuration file is managed via the virt-who configure plugin
### manual edits will be deleted.
VIRTWHO_DEBUG=0
VIRTWHO_INTERVAL=43200
NO_PROXY=*
```

## Existing Deployments:

```bash
[root@dhcp-8-30-209 ~]# cat /etc/sysconfig/virt-who
### This configuration file is managed via the virt-who configure plugin
### manual edits will be deleted.
VIRTWHO_DEBUG=0
VIRTWHO_INTERVAL=43200
NO_PROXY=*
```

### After new deployment:

* Updated wording on step that creates config
`== [4/5] Creating sysconfig virt-who configuration and removing old configuration file if present ==`
```bash
[root@dhcp-8-30-209 ~]# cat /etc/virt-who.conf
### This configuration file is managed via the virt-who configure plugin
### manual edits will be deleted.
VIRTWHO_DEBUG=0
VIRTWHO_INTERVAL=43200
NO_PROXY=*
```

Old virt-who file removed and service running ok and both configs reporting success 

```bash
[root@dhcp-8-30-209 ~]# systemctl status virt-who.service
● virt-who.service - Daemon for reporting virtual guest IDs to subscription-manager
   Loaded: loaded (/usr/lib/systemd/system/virt-who.service; enabled; vendor preset: disabled)
   Active: active (running) since Thu 2021-04-01 16:11:47 EDT; 2min 24s ago
```

https://nimb.ws/T4UtIn