### PR TITLE
Fixes #32247 - Remove XenServer from hypervisor list

### DIFF
--- a/app/helpers/foreman_virt_who_configure/configs_helper.rb
+++ b/app/helpers/foreman_virt_who_configure/configs_helper.rb
@@ -4,9 +4,7 @@ module ForemanVirtWhoConfigure
       @hypervisor_server_help_data ||= {
         'esx' => _('VMware vCenter server’s fully qualified host name or IP address.'),
         'rhevm' => _('Red Hat Virtualization Manager’s fully qualified host name or IP address. For example, <code>https://hostname:443/ovirt-engine/</code> for v4, <code>https://hostname_or_IP:443</code> for v3'),
-        # 'vdsm' => 'Red Hat Enterprise Linux Hypervisor (vdsm)',
         'hyperv' => _('Microsoft Hyper-V fully qualified host name or IP address.'),
-        'xen' => _('XenServer server’s fully qualified host name or IP address.'),
         'libvirt' => _('Libvirt server’s fully qualified host name or IP address. You can also specify preferred schema, for example: <code>qemu+ssh://libvirt.example.com/system</code>. If you use SSH, make sure you setup root\'s SSH key on target host for a user specified at hypervisor username field'),
         'kubevirt' => _('Container-native virtualization’s fully qualified host name or IP address. In order to connect to the cluster it is required to provide path to kubeconfig which contains connection details and authentication token.')
       }
@@ -16,9 +14,7 @@ module ForemanVirtWhoConfigure
       @hypervisor_username_help_data ||= {
         'esx' => _('Account name by which virt-who is to connect to the hypervisor, in the format <code>domain_name\account_name</code>. Note that only a single backslash separates the values for domain_name and account_name. If you are using a domain account, and the global configuration file <code>/etc/sysconfig/virt-who</code>, then <b>two</b> backslashes are required. For further details, see <a href="https://access.redhat.com/solutions/1270223">Red Hat Knowledgebase solution How to use a windows domain account with virt-who</a> for more information.'),
         'rhevm' => _('Account name by which virt-who is to connect to the Red Hat Enterprise Virtualization Manager instance. The username option requires input in the format username@domain.'),
-        # 'vdsm' => '',
         'hyperv' => _('Account name by which virt-who is to connect to the hypervisor. By default this is <code>Administrator</code>. To use an alternate account, create a user account and assign that account to the following groups (Windows 2012 Server): Hyper-V Administrators and Remote Management Users.'),
-        'xen' => _('Account name by which virt-who is to connect to the hypervisor.'),
         'libvirt' => _('Account name by which virt-who is to connect to the hypervisor. Virt-who does not support password based authentication, you must manually setup SSH key, see <a href="https://access.redhat.com/solutions/1515983">Red Hat Knowledgebase solution How to configure virt-who for a KVM host</a> for more information.'),
         'kubevirt' => ''
       }

--- a/app/models/foreman_virt_who_configure/config.rb
+++ b/app/models/foreman_virt_who_configure/config.rb
@@ -32,9 +32,7 @@ module ForemanVirtWhoConfigure
     HYPERVISOR_TYPES = {
       'esx' => 'VMware vSphere / vCenter (esx)',
       'rhevm' => 'Red Hat Virtualization Hypervisor (rhevm)',
-      # 'vdsm' => 'Red Hat Enterprise Linux Hypervisor (vdsm)',
       'hyperv' => 'Microsoft Hyper-V (hyperv)',
-      'xen' => 'XenServer (xen)',
       'libvirt' => 'libvirt',
       'kubevirt' => 'Container-native virtualization'
     }

--- a/db/migrate/20210413165147_delete_xen_profiles.rb
+++ b/db/migrate/20210413165147_delete_xen_profiles.rb
@@ -1,0 +1,5 @@
+class DeleteXenProfiles < ActiveRecord::Migration[6.0]
+  def change
+    ForemanVirtWhoConfigure::Config.where(:hypervisor_type => 'xen').destroy_all
+  end
+end


### PR DESCRIPTION
Removed VDSM as well since that was the old RHV and has been commented out for a while.

Screenshot of XEN removed from the UI:

https://nimb.ws/1KQcaw