### PR TITLE
Fixes #33483 - Add ability to create/update with Kubevirt

### DIFF
--- a/app/controllers/foreman_virt_who_configure/api/v2/configs_controller.rb
+++ b/app/controllers/foreman_virt_who_configure/api/v2/configs_controller.rb
@@ -47,11 +47,12 @@ module ForemanVirtWhoConfigure
             param :exclude_host_parents, String, :desc => N_("Applicable only for esx provider type. Hosts which parent (usually ComputeResource) name is specified in comma-separated list in this option will <b>NOT</b> be reported. Wildcards and regular expressions are supported, multiple records must be separated by comma. Put the value into the double-quotes if it contains special characters like comma. All new line characters will be removed in resulting configuration file, white spaces are removed from beginning and end."), :required => false
             param :hypervisor_id, Config::HYPERVISOR_IDS, :desc => N_("Specifies how the hypervisor will be identified."), :required => true
             param :hypervisor_type, Config::HYPERVISOR_TYPES.keys, :desc => N_("Hypervisor type"), :required => true
-            param :hypervisor_server, String, :desc => N_("Fully qualified host name or IP address of the hypervisor"), :required => true
-            param :hypervisor_username, String, :desc => N_("Account name by which virt-who is to connect to the hypervisor."), :required => true
-            param :hypervisor_password, String, :desc => N_("Hypervisor password, required for all hypervisor types except for libvirt"), :required => false
+            param :hypervisor_server, String, :desc => N_("Fully qualified host name or IP address of the hypervisor"), :required => false
+            param :hypervisor_username, String, :desc => N_("Account name by which virt-who is to connect to the hypervisor."), :required => false
+            param :hypervisor_password, String, :desc => N_("Hypervisor password, required for all hypervisor types except for libvirt/kubevirt."), :required => false
             param :satellite_url, String, :desc => N_("Foreman server FQDN"), :required => true
             param :debug, :bool, :desc => N_("Enable debugging output")
+            param :kubeconfig_path, String, :desc => N_('Configuration file containing details about how to connect to the cluster and authentication details.'), :required => false
             param :http_proxy_id, Integer, :desc => N_('HTTP proxy that should be used for communication between the server on which virt-who is running and the hypervisors and virtualization managers.')
             param :no_proxy, String, :desc => N_("Ignore proxy. A comma-separated list of hostnames or domains or ip addresses to ignore proxy settings for. Optionally this may be set to * to bypass proxy settings for all hostnames domains or ip addresses.")
             param :organization_id, Integer, :required => true, :desc => N_("Organization of the virt-who configuration") if ::SETTINGS[:organizations_enabled]

--- a/app/models/foreman_virt_who_configure/config.rb
+++ b/app/models/foreman_virt_who_configure/config.rb
@@ -108,6 +108,7 @@ module ForemanVirtWhoConfigure
     validates :hypervisor_password, :presence => true, :if => Proc.new { |c| c.hypervisor_type != 'libvirt' && c.hypervisor_type != 'kubevirt' }
     validates :hypervisor_username, :presence => true, :if => Proc.new { |c| c.hypervisor_type != 'kubevirt' }
     validates :hypervisor_server, :presence => true, :if => Proc.new { |c| c.hypervisor_type != 'kubevirt' }
+    validates :kubeconfig_path, :presence => true, :if => Proc.new { |c| c.hypervisor_type == 'kubevirt' }
     validates :hypervisor_type, :inclusion => HYPERVISOR_TYPES.keys
     validates :hypervisor_id, :inclusion => HYPERVISOR_IDS
     validates :interval, :inclusion => AVAILABLE_INTERVALS.keys.map(&:to_i)


### PR DESCRIPTION
## PR Description

In the UI we set those values to nil since they do not appear in the ui and are not used with Kubevirt since that info is in the config file. Without them set to `nil` hammer requires those params when trying to use type kubevirt and fails to run the command.

We can see that from the POST API call here when I made one from the UI:

```ruby
14:37:40 rails.1   | 2021-09-13T14:37:40 [I|app|5c3938ee] Started POST "/foreman_virt_who_configure/configs" for 192.168.177.1 at 2021-09-13 14:37:40 -0400
14:37:40 rails.1   | 2021-09-13T14:37:40 [I|app|5c3938ee] Processing by ForemanVirtWhoConfigure::ConfigsController#create as HTML
14:37:40 rails.1   | 2021-09-13T14:37:40 [I|app|5c3938ee]   Parameters: {"utf8"=>"✓", "authenticity_token"=>"DeGnALlb+C21L9RakAz1UltIynP28hNLjCqws/uk4MQI7NxW21dpXYcxHu3H/5n18BmJY17UBqTMK4RU1KtWlA==", "foreman_virt_who_configure_config"=>{"name"=>"test", "organization_id"=>"1", "hypervisor_type"=>"kubevirt", "hypervisor_server"=>"", "hypervisor_username"=>"", "hypervisor_password"=>"[FILTERED]", "interval"=>"120", "satellite_url"=>"devel.katello.lan", "hypervisor_id"=>"hostname", "listing_mode"=>"0", "whitelist"=>"", "blacklist"=>"", "filter_host_parents"=>"", "exclude_host_parents"=>"", "debug"=>"0", "http_proxy_id"=>"", "no_proxy"=>"", "kubeconfig_path"=>"/tmp/food"}, "commit"=>"Submit"}
```

#### Results with patch:

```bash
[vagrant@hammer ~]$ hammer virt-who-config create --name="gCBHwsVPFs" --debug="1" --interval="60" --hypervisor-id="hostname" --hypervisor-type="kubevirt" --organization-id="1" --filtering-mode="none" --satellite-url="ent-02-vm-03.lab.eng.nay.redhat.com" --kubeconfig-path="/root/kube.conf"

Virt Who configuration [gCBHwsVPFs] created
```

#### Update still works
```
[vagrant@hammer ~]$ hammer virt-who-config update --id 3 --kubeconfig-path '/tmp/burgers'
Virt Who configuration [gCBHwsVPFs] updated
```

#### Not submitting the kubeconfig_path param when creating a config:
```bash
[vagrant@hammer ~]$ hammer virt-who-config create --name="gCBHwsVPFs" --debug="1" --interval="60" --hypervisor-id="hostname" --hypervisor-type="kubevirt" --organization-id="1" --filtering-mode="none" --satellite-url="ent-02-vm-03.lab.eng.nay.redhat.com"

Could not create the Virt Who configuration:
  Kubeconfig path can't be blank
```

#### Trying to submit the kubeconfig_path param with another type of hypervisor:
```bash
[vagrant@hammer ~]$ hammer virt-who-config create --name="gCBHwsVPF1" --debug="1" --interval="60" --hypervisor-id="hostname" --hypervisor-type="esx" --organization-id="1" --filtering-mode="none" --satellite-url="ent-02-vm-03.lab.eng.nay.redhat.com" --kubeconfig-path '/tmp/burgers' --hypervisor-password="hi" --hypervisor-username="admin" --hypervisor-server="test.example.com"

Could not create the Virt Who configuration:
  Kubeconfig path Can not be used with non Kubevirt hypervisor type.
```