### PR TITLE
Fixes #35062 - avoid data contamination in field validation

### DIFF
--- a/app/models/foreman_virt_who_configure/config.rb
+++ b/app/models/foreman_virt_who_configure/config.rb
@@ -139,9 +139,7 @@ module ForemanVirtWhoConfigure
     end    
 
     def validates_hypervisor_options
-      invalid = hypervisor_type == 'kubevirt' ? KUBEVIRT_INVALID_OPTIONS : KUBEVIRT_VALID_OPTIONS
-      invalid.concat(AHV_VALID_OPTIONS) unless hypervisor_type == 'ahv'
-      invalid.each { |f| errors.add(f, "Invalid option for hypervisor [#{hypervisor_type}]") if eval(f).present? }
+      invalid_fields.each { |f| errors.add(f, "Invalid option for hypervisor [#{hypervisor_type}]") if eval(f).present? }
     end
 
     validates_lengths_from_database
@@ -275,6 +273,17 @@ module ForemanVirtWhoConfigure
 
     def remove_whitespaces
       satellite_url.strip! if satellite_url.present?
+    end
+
+    def invalid_fields
+      case hypervisor_type
+      when 'kubevirt'
+        KUBEVIRT_INVALID_OPTIONS + AHV_VALID_OPTIONS
+      when 'ahv'
+        KUBEVIRT_VALID_OPTIONS
+      else
+        KUBEVIRT_VALID_OPTIONS + AHV_VALID_OPTIONS
+      end
     end
   end
 end


### PR DESCRIPTION
Changed the way to set up the invalid fields when a `hypervisor_type` is selected.

**To test**
1 Create a virt-who config for a non-Nutanix type, eg. Container-native virtualization
2 Create a Nutanix virt-who config 
   This would fail without fix with error Prism flavor Invalid option for hypervisor [ahv]. 
   Then apply the fix and repeat the steps. All configs should be created without issues.