### PR TITLE
Fixes #35081 - remove outdated configuration env=Library

### DIFF
--- a/app/models/foreman_virt_who_configure/output_generator.rb
+++ b/app/models/foreman_virt_who_configure/output_generator.rb
@@ -117,7 +117,7 @@ if verify_minimal_version; then
 type=#{type}
 hypervisor_id=#{hypervisor_id}
 owner=#{owner}
-env=Library#{connection_details}#{filtering}
+#{connection_details}#{filtering}
 rhsm_hostname=#{satellite_url}
 rhsm_username=#{service_user_username}
 rhsm_encrypted_password=$user_password


### PR DESCRIPTION
From virt-who-0.24.6-1.el7, the env option was removed
refer to https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=902265
the first item in changelog

- 1530290: Remove enviroment as an input variable for the hypervisor check in
  ([wpoteat@redhat.com](mailto:wpoteat@redhat.com))