### PR TITLE
Fixes #35739 - Use ahv_internal_debug instead of internal_debug for n…

### DIFF
--- a/app/models/foreman_virt_who_configure/output_generator.rb
+++ b/app/models/foreman_virt_who_configure/output_generator.rb
@@ -170,7 +170,7 @@ encrypted_password=$cr_password"
       if config.hypervisor_type == 'ahv'
         prism_central = config.prism_flavor == "central"
         update_interval = config.ahv_update_interval.present? ? "\nupdate_interval=#{config.ahv_update_interval}" : nil
-        internal_debug = config.ahv_internal_debug.present? ? "\ninternal_debug=#{config.ahv_internal_debug}" : nil
+        internal_debug = config.ahv_internal_debug.present? ? "\nahv_internal_debug=#{config.ahv_internal_debug}" : nil
 
         "\nprism_central=#{prism_central}#{internal_debug}#{update_interval}"
       else

--- a/test/unit/output_generator_test.rb
+++ b/test/unit/output_generator_test.rb
@@ -139,7 +139,7 @@ module ForemanVirtWhoConfigure
         assert_includes output, 'type=ahv'
         assert_includes output, 'prism_central=true'
         assert_includes output, 'update_interval=100'
-        assert_includes output, 'internal_debug=true'
+        assert_includes output, 'ahv_internal_debug=true'
       end
 
       test 'options specific to ahv are not all set' do


### PR DESCRIPTION
Use `ahv_internal_debug=true` instead of `internal_debug=true` for nutanix virt-who config