### PR TITLE
Fixes #36048 - update_attributes no longer works in Rails 6.1

### DIFF
--- a/app/controllers/foreman_virt_who_configure/api/v2/configs_controller.rb
+++ b/app/controllers/foreman_virt_who_configure/api/v2/configs_controller.rb
@@ -75,7 +75,7 @@ module ForemanVirtWhoConfigure
         param_group :config
 
         def update
-          process_response @config.update_attributes(config_params)
+          process_response @config.update(config_params)
         end
 
         api :DELETE, '/configs/:id', N_("Delete a virt-who configuration")

--- a/app/controllers/foreman_virt_who_configure/configs_controller.rb
+++ b/app/controllers/foreman_virt_who_configure/configs_controller.rb
@@ -49,7 +49,7 @@ module ForemanVirtWhoConfigure
     end
 
     def update
-      if @config.update_attributes(config_params)
+      if @config.update(config_params)
         process_success :object => @config
       else
         process_error :object => @config


### PR DESCRIPTION
In Rails 6.1, the update_attributes method no longer works.

**To Test**
1 Edit virt who config from UI
2 hammer virt-who-config update --interval 240 --id 1 