### PR TITLE
Fixes #36372 - Show correct config name during create\update\delete

### DIFF
--- a/app/controllers/foreman_virt_who_configure/configs_controller.rb
+++ b/app/controllers/foreman_virt_who_configure/configs_controller.rb
@@ -36,7 +36,7 @@ module ForemanVirtWhoConfigure
     def create
       @config = Config.new(config_params)
       if @config.save
-        process_success :success_redirect => foreman_virt_who_configure_config_path(@config), :object => @config
+        process_success :success_redirect => foreman_virt_who_configure_config_path(@config), :object => @config.name
       else
         render 'new'
       end
@@ -50,17 +50,17 @@ module ForemanVirtWhoConfigure
 
     def update
       if @config.update(config_params)
-        process_success :object => @config
+        process_success :object => @config.name
       else
-        process_error :object => @config
+        process_error :object => @config.name
       end
     end
 
     def destroy
       if @config.destroy
-        process_success :object => @config
+        process_success :object => @config.name
       else
-        process_error :object => @config
+        process_error :object => @config.name
       end
     end
 


### PR DESCRIPTION
Create: https://github.com/theforeman/foreman_virt_who_configure/blob/master/app/controllers/foreman_virt_who_configure/configs_controller.rb#L36-L43

Update: https://github.com/theforeman/foreman_virt_who_configure/blob/master/app/controllers/foreman_virt_who_configure/configs_controller.rb#L51-L57

Delete: https://github.com/theforeman/foreman_virt_who_configure/blob/master/app/controllers/foreman_virt_who_configure/configs_controller.rb#L59-L65

We always seem to call @config and hence the Success message just prints something like '#<ForemanVirtWhoConfigure::Config:0x000055f23eed3d30>'. We should call @config.name here.

