### PR TITLE
Ref #36499 - libvirt configuration needs server and username

### DIFF
--- a/app/assets/javascripts/foreman_virt_who_configure/config_edit.js
+++ b/app/assets/javascripts/foreman_virt_who_configure/config_edit.js
@@ -28,13 +28,13 @@ function virt_who_update_listing_mode() {
 function virt_who_update_hypervisor_fields() {
   selected_type = $('#foreman_virt_who_configure_config_hypervisor_type').val();
   var element = $('#foreman_virt_who_configure_config_hypervisor_username');
-  element.closest('.form-group').toggle(selected_type != 'libvirt' && selected_type != 'kubevirt');
+  element.closest('.form-group').toggle(selected_type != 'kubevirt');
   var element = $('#foreman_virt_who_configure_config_hypervisor_password');
   element.closest('.form-group').toggle(selected_type != 'libvirt' && selected_type != 'kubevirt');
   var element = $('#foreman_virt_who_configure_config_kubeconfig_path');
   element.closest('.form-group').toggle(selected_type == 'kubevirt');
   var element = $('#foreman_virt_who_configure_config_hypervisor_server');
-  element.closest('.form-group').toggle(selected_type != 'libvirt' && selected_type != 'kubevirt');
+  element.closest('.form-group').toggle(selected_type != 'kubevirt');
   var element = $('#foreman_virt_who_configure_config_ahv_internal_debug');
   element.closest('.form-group').toggle(selected_type == 'ahv');
   virt_who_update_listing_mode();

--- a/app/models/foreman_virt_who_configure/config.rb
+++ b/app/models/foreman_virt_who_configure/config.rb
@@ -106,8 +106,8 @@ module ForemanVirtWhoConfigure
               :presence => true
     validates :name, :uniqueness => { :scope => :organization_id }
     validates :hypervisor_password, :presence => true, :if => Proc.new { |c| c.hypervisor_type != 'libvirt' && c.hypervisor_type != 'kubevirt' }
-    validates :hypervisor_username, :presence => true, :if => Proc.new { |c| c.hypervisor_type != 'libvirt' && c.hypervisor_type != 'kubevirt' }
-    validates :hypervisor_server, :presence => true, :if => Proc.new { |c| c.hypervisor_type != 'libvirt' && c.hypervisor_type != 'kubevirt' }
+    validates :hypervisor_username, :presence => true, :if => Proc.new { |c| c.hypervisor_type != 'kubevirt' }
+    validates :hypervisor_server, :presence => true, :if => Proc.new { |c| c.hypervisor_type != 'kubevirt' }
     validates :kubeconfig_path, :presence => true, :if => Proc.new { |c| c.hypervisor_type == 'kubevirt' }
     validates :hypervisor_type, :inclusion => HYPERVISOR_TYPES.keys
     validates :hypervisor_id, :inclusion => HYPERVISOR_IDS

--- a/app/models/foreman_virt_who_configure/output_generator.rb
+++ b/app/models/foreman_virt_who_configure/output_generator.rb
@@ -160,7 +160,8 @@ EOS
       if config.hypervisor_type == 'kubevirt'
         ""
       elsif config.hypervisor_type == 'libvirt'
-        "\nserver=qemu:///system"
+        "\nserver=#{cr_server}
+username=#{cr_username}"
       else
         "\nserver=#{cr_server}
 username=#{cr_username}


### PR DESCRIPTION
`server=qemu:///system` is the configuration for kvm hypervisor where virt-who is installed locally on the hypervisor 
and the configuration script runs on the kvm hypervisor as well.

The virt-who support for rhevm is to run the virt-who configuration script on the satellite server.
The configuration needs the information about the hypervisor server and username.
Satellite server's SSH key should be added to rhevm hypervisor's authorized_keys.

Followup of https://github.com/theforeman/foreman_virt_who_configure/pull/166

**Steps to test**
  1. copy satellite server's key to rhevm hypervisor
 	# ssh-keygen -t rsa -P '' -f /root/.ssh/id_rsa ; ssh-copy-id -i /root/.ssh/id_rsa.pub  hypervisor.redhat.com
  2. Register guest to satellite
  3. Create virt-who config with hypervisor type libvirt
  4. Deploy virt-who config on satellite server
 	# hammer virt-who-config deploy --id 1 --organization-id 1
  5. check mapping info in /var/log/rhsm/rhsm.log

