### PR TITLE
Refs #36499 - virt-who has to use SSH key to connect to libvirt server

### DIFF
--- a/app/helpers/foreman_virt_who_configure/configs_helper.rb
+++ b/app/helpers/foreman_virt_who_configure/configs_helper.rb
@@ -4,7 +4,7 @@ module ForemanVirtWhoConfigure
       @hypervisor_server_help_data ||= {
         'esx' => _('VMware vCenter server’s fully qualified host name or IP address.'),
         'hyperv' => _('Microsoft Hyper-V fully qualified host name or IP address.'),
-        'libvirt' => _('Libvirt server’s fully qualified host name or IP address. You can also specify preferred schema, for example: <code>qemu+ssh://libvirt.example.com/system</code>. If you use SSH, make sure you setup root\'s SSH key on target host for a user specified at hypervisor username field'),
+        'libvirt' => _('Libvirt server’s fully qualified host name or IP address. You can also specify preferred schema, for example: <code>qemu+ssh://libvirt.example.com/system</code>. Make sure you setup root\'s SSH key on target host for a user specified at hypervisor username field'),
         'kubevirt' => _('Container-native virtualization’s fully qualified host name or IP address. In order to connect to the cluster it is required to provide path to kubeconfig which contains connection details and authentication token.'),
         'ahv' => _('Nutanix AHV’s IP address.')
       }


### PR DESCRIPTION
SSH key is required to connect to libvirt server. 
Make the help message clearer.