### PR TITLE
Fixes #36855 - Use one ServiceUser for all configs in an organization

### DIFF
--- a/app/models/foreman_virt_who_configure/service_user.rb
+++ b/app/models/foreman_virt_who_configure/service_user.rb
@@ -6,7 +6,7 @@ module ForemanVirtWhoConfigure
     encrypts :encrypted_password
 
     belongs_to :user
-    has_one :config
+    has_many :configs, :inverse_of => :service_user
 
     # Foreman 1.11 specifics, can be removed later, otherwise when string does not start with "encrypts" prefix
     # we get 500 when we try to create log message that relies on name method

--- a/db/migrate/20231024171433_add_organization_id_to_service_user.rb
+++ b/db/migrate/20231024171433_add_organization_id_to_service_user.rb
@@ -1,0 +1,22 @@
+class AddOrganizationIdToServiceUser < ActiveRecord::Migration[6.1]
+  def up
+    add_column :foreman_virt_who_configure_service_users, :organization_id, :integer
+
+    ::ForemanVirtWhoConfigure::Config.find_each do |config|
+      service_user = ::ForemanVirtWhoConfigure::ServiceUser.find_by(organization_id: config.organization_id)
+      if service_user.present?
+         config.update_columns(service_user_id: service_user.id)
+         next
+      end
+
+      cfg_service_user = ::ForemanVirtWhoConfigure::ServiceUser.find_by(id: config.service_user_id)
+      cfg_service_user.update_columns(organization_id: config.organization_id)
+    end
+
+    ::ForemanVirtWhoConfigure::ServiceUser.where(organization_id: nil).destroy_all
+  end
+
+  def down
+    remove_column :foreman_virt_who_configure_service_users, :organization_id, :integer
+  end
+end


### PR DESCRIPTION
All configs for the same provider in one organization should use the same ServiceUser to talk to RHSM. 

Tests
- Creating the first config for a provider in one organization would create a service user and user as well.
- Creating more configs for the above provider in the same organization would share the same service user and user as for the first config.
- Creating a config for the same provider but in different organization would create a new service user and user.
- Deleting a config would not remove the service user and user if there are other configs for the same provider.
- Deleting the last config for a provider would also remove the service user and user.