### PR TITLE
Fixes #37054 - Fix config reporting in the UI

### DIFF
--- a/app/lib/actions/foreman_virt_who_configure/config/report.rb
+++ b/app/lib/actions/foreman_virt_who_configure/config/report.rb
@@ -19,9 +19,8 @@ module Actions
           #   # but we should be careful anyway
           #   hypervisor = ::Host.joins(:subscription_facet).where(:'katello_subscription_facets.uuid' => hv_attrs['uuid']).first
           # end
-
-          config = ::ForemanVirtWhoConfigure::ServiceUser.find_by_user_id(User.current.id).try(:config)
-          if config.present?
+          configs = ::ForemanVirtWhoConfigure::ServiceUser.find_by_user_id(User.current.id).try(:configs)
+          configs&.each do |config|
             config.virt_who_touch!
           end
 


### PR DESCRIPTION
What are the changes introduced in this pull request?

* We changed how configs worked in this PR https://github.com/theforeman/foreman_virt_who_configure/commit/d9a1b9082398ab0e9ab8c6fbe51b8f53384b3975 so all configs use 1 service user per organization instead of creating a user for each config which breaks virt-who when you have lots of configs being reported in. See [here](https://bugzilla.redhat.com/show_bug.cgi?id=2173870#c4) why

Considerations taken when implementing this change?

* Right now, there is a limitation of virt-who which does not send which config on the filesystem it used and just groups everything into a single report. This makes it hard for us to determine which configs in the UI need to be updated. After talking with Partha, we have decided to just mark them all green when a virt-who report comes in and file an RFE to virt-who to attach the config/s name used in the JSON report it sends. That can be tracked here:

https://issues.redhat.com/browse/RHEL-21652

Once this is addressed we will go back and update the reporting task, look at the JSON for the config name and properly update them instead of marking them all green.

What are the testing steps for this pull request?

* Install virt-who configure plugin either by adding it to forklift in extra plugins, or cloning the repo, adding to `bundler.d` in the `foreman` directory and then doing a `db:migrate` `db:seed`
* Check out PR
* Create a config for VMware (Ping me for creds)
* Create a 2nd config for a different VMware instance (ping me for creds)
* Run the deploy scripts for each one, verify that each report updates in the UI
* Run `systemctl restart virt-who` verify both configs report green (This will fire both off at the same time)

Without PR by doing this, virt-who will report in, but the configs say `No reported data`