### PR TITLE
Fixes #26319 - Lock Foreman URL field in config

### DIFF
--- a/app/views/foreman_virt_who_configure/configs/steps/_connection_form.erb
+++ b/app/views/foreman_virt_who_configure/configs/steps/_connection_form.erb
@@ -1,5 +1,5 @@
 <div id="config_connection">
-  <%= text_f f, :satellite_url, inline_help_popover(_('Foreman server’s fully-qualified host name, for example: foreman.example.com')).merge(:label => _('Foreman server FQDN')) %>
+  <%= text_f f, :satellite_url, inline_help_popover(_('Foreman server’s fully-qualified host name, for example: foreman.example.com')).merge(:label => _('Foreman server FQDN'), readonly: true) %>
   <%= select_f f, :hypervisor_id, ForemanVirtWhoConfigure::Config::HYPERVISOR_IDS, :to_s, :to_s, {}, { :label => _('Hypervisor ID') }.merge(
         inline_help_popover(_("Specifies that hypervisors will be identified by their <b>hostname</b>, <b>uuid</b> or <b>hwuuid</b>.
                               Note that some virtualization backends don't have all of them implemented.


### PR DESCRIPTION
## What are the changes introduced in this pull request?
* Locked the Foreman/Satellite URL field so users don't make a mistake with changing that since it's just for info purposes

## Considerations taken when implementing this change?
* Used `:readonly` since looking online `:disabled` does not send the params back
* https://www.linkedin.com/pulse/disabled-vs-readonly-html-attributes-peter-mbanugo-tyuhe/

## What are the testing steps for this pull request?
*  Check out PR
* Create a config and verify the field is read only