### PR TITLE
Fixes #26321 - Only allow hwuuid for VMware hypervisors

### DIFF
--- a/app/assets/javascripts/foreman_virt_who_configure/config_edit.js
+++ b/app/assets/javascripts/foreman_virt_who_configure/config_edit.js
@@ -5,6 +5,14 @@ function virt_who_update_listing_mode() {
   var blacklist = $('#foreman_virt_who_configure_config_blacklist').parents('div.form-group');
   var whitelist_parent = $('#foreman_virt_who_configure_config_filter_host_parents').parents('div.form-group');
   var blacklist_parent = $('#foreman_virt_who_configure_config_exclude_host_parents').parents('div.form-group');
+  var hypervisor_ids = foreman_virt_who_configure_config_hypervisor_id;
+
+  // https://projects.theforeman.org/issues/26321
+    if (hypervisor_type != 'esx') {
+      $(hypervisor_ids).find('option[value=hwuuid]').remove();
+    } else if (hypervisor_type == 'esx' && $(hypervisor_ids).find('option[value=hwuuid]').length == 0) {
+      $(hypervisor_ids).append('<option value='+'hwuuid>'+'hwuuid'+'</option>');
+    }
 
   // UNLIMITED = 0, WHITELIST = 1, BLACKLIST = 2, see config.rb model for the definition
   if (filtering_mode == '0') {

--- a/app/assets/javascripts/foreman_virt_who_configure/config_edit.js
+++ b/app/assets/javascripts/foreman_virt_who_configure/config_edit.js
@@ -8,11 +8,11 @@ function virt_who_update_listing_mode() {
   var hypervisor_ids = foreman_virt_who_configure_config_hypervisor_id;
 
   // https://projects.theforeman.org/issues/26321
-    if (hypervisor_type != 'esx') {
-      $(hypervisor_ids).find('option[value=hwuuid]').remove();
-    } else if (hypervisor_type == 'esx' && $(hypervisor_ids).find('option[value=hwuuid]').length == 0) {
-      $(hypervisor_ids).append('<option value='+'hwuuid>'+'hwuuid'+'</option>');
-    }
+  if (hypervisor_type != 'esx') {
+    $(hypervisor_ids).find('option[value=hwuuid]').remove();
+  } else if (hypervisor_type == 'esx' && $(hypervisor_ids).find('option[value=hwuuid]').length == 0) {
+    $(hypervisor_ids).append('<option value='+'hwuuid>'+'hwuuid'+'</option>');
+  }
 
   // UNLIMITED = 0, WHITELIST = 1, BLACKLIST = 2, see config.rb model for the definition
   if (filtering_mode == '0') {

--- a/app/models/foreman_virt_who_configure/config.rb
+++ b/app/models/foreman_virt_who_configure/config.rb
@@ -116,6 +116,7 @@ module ForemanVirtWhoConfigure
     validates :prism_flavor, :inclusion => {:in => PRISM_FLAVORS.keys, :message => "should be either central or element"}, :if => proc { |c| c.hypervisor_type == 'ahv' }
     validate :validates_whitelist_blacklist
     validate :validates_debug_settings, :if => proc { |c| c.hypervisor_type == 'ahv' }
+    validate :validates_hypervisor_id_non_vmware, :if => proc { |c| c.hypervisor_type != 'esx' }
     validate :validates_hypervisor_options
 
     def validates_whitelist_blacklist
@@ -128,6 +129,13 @@ module ForemanVirtWhoConfigure
           unless blacklist.present? || exclude_host_parents.present?
             [:blacklist, :exclude_host_parents].each { |f| errors.add(f, "Exclude hosts or Exclude host parents is required") }
           end
+      end
+    end
+
+    def validates_hypervisor_id_non_vmware
+      return unless hypervisor_id.present?
+      if hypervisor_id == 'hwuuid'
+        errors.add(:hypervisor_id, "hwuuid is only supported for ESX hypervisor type")
       end
     end
 

--- a/test/functional/api/v2/configs_controller_test.rb
+++ b/test/functional/api/v2/configs_controller_test.rb
@@ -167,6 +167,27 @@ class ForemanVirtWhoConfigure::Api::V2::ConfigsControllerTest < ActionController
     assert_equal "Kubeconfig path Invalid option for hypervisor [esx]", response['error']['full_messages'].join('')
   end
 
+  test "should error when hypervisor type is hwuuid and type is not vmware" do
+    org = FactoryBot.create(:organization)
+    post :create, :params => { :foreman_virt_who_configure_config => { :name => 'my new config',
+                                                            :interval => 240,
+                                                            :filtering_mode => ForemanVirtWhoConfigure::Config::BLACKLIST,
+                                                            :blacklist => ' a,b ',
+                                                            :hypervisor_id => 'hwuuid',
+                                                            :hypervisor_type => 'libvirt',
+                                                            :hypervisor_server => "libvirt.example.com",
+                                                            :hypervisor_username => "root",
+                                                            :debug => true,
+                                                            :satellite_url => "foreman.example.com",
+                                                            :organization_id => org.id }
+    }, :session => set_session_user
+
+    assert_response :unprocessable_entity
+
+    response = ActiveSupport::JSON.decode(@response.body)
+    assert_equal "Hypervisor hwuuid is only supported for ESX hypervisor type", response['error']['full_messages'].join('')
+  end
+
   test "should create the config" do
     org = FactoryBot.create(:organization)
     post :create, :params => { :foreman_virt_who_configure_config => { :name => 'my new config',


### PR DESCRIPTION
## What are the changes introduced in this pull request?
* Added a model validation to prevent `hwuuid` being saved with a non esx `hypervisor_type`
* Added some JQuery logic to remove and add the `hwuuid` from the `hypervisor_id` dropdown based on the `hypervisor_type`
* Added a unit test for the model validation change

## What are the testing steps for this pull request?
* Check out PR
* Create a config and select the hypervisor type as VMware and make sure `hwuuid` is in the `hypervisor_id` dropdown
* Change the dropdown to anything except VMware and make sure `hwuuid` is removed from the `hypervisor_id` dropdown
* Try with hammer to make a config and pass in `hwuuid` hypervisor-id with a non esx hypervisor type and see if the validation fails with the error I added