### PR TITLE
Revert "Test with Katello"

### DIFF
--- a/gemfile.d/katello.rb
+++ b/gemfile.d/katello.rb
@@ -1,1 +1,0 @@
-gem 'katello', github: 'Katello/katello', branch: 'master'


### PR DESCRIPTION
This reverts commit b0ae4c6cf9566abccfb6d31f8598c34fb4310993.

This prevents this error
```
[!] There was an error parsing `Gemfile`: You cannot specify the same gem twice coming from different sources.
You specified that katello (>= 0) should come from https://github.com/Katello/katello.git and source at `../katello`
. Bundler cannot continue.

 #  from /home/vagrant/foreman/Gemfile:59
 #  -------------------------------------------
 #    puts "looking at '#{bundle}'"
 >    instance_eval(Bundler.read_file(bundle))
 #  end
 #  -------------------------------------------

```