### PR TITLE
Only add katello as a dependency if not already declared

### DIFF
--- a/gemfile.d/katello.rb
+++ b/gemfile.d/katello.rb
@@ -1,1 +1,3 @@
-gem 'katello', github: 'Katello/katello', branch: 'master'
+unless dependencies.find { |d| d.name == 'katello' } || gemspecs.find { |d| d.name == 'katello' }
+  gem 'katello', github: 'Katello/katello', branch: 'master'
+end


### PR DESCRIPTION
This inspects the known dependencies and only adds katello if it's not already defined. This is needed because in development it's common to have local git checkouts, but then still load all `gemfile.d/*.rb` files from the various plugins.

This is an alternative to https://github.com/theforeman/foreman_virt_who_configure/pull/201.