### PR TITLE
Fixes #39271 - Move theforeman-rubocop and rdoc into Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'rdoc'
+gem 'theforeman-rubocop', '~> 0.1.2', require: false, groups: %i[development rubocop]

--- a/foreman_virt_who_configure.gemspec
+++ b/foreman_virt_who_configure.gemspec
@@ -28,6 +28,4 @@ Gem::Specification.new do |s|
   s.test_files = Dir['test/**/*']
 
   s.add_dependency 'katello'
-  s.add_development_dependency('theforeman-rubocop', '~> 0.0.6')
-  s.add_development_dependency 'rdoc'
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Move theforeman-rubocop and rdoc dependencies to Gemfile instead of specifying it in gemspec.

#### Considerations taken when implementing this change?

With newer bundler and the way we setup the Foreman with plugins, there are resolution failures due to duplicated dependencies.

#### What are the testing steps for this pull request?

Run `bundle install` with any other plugin that has the same dependency with a different version.

Before: fails to resolve (or there are warnings on older bundler version)
After: passes without any issue, rubocop still works locally and in CI