### PR TITLE
Remove hammer CLI references from plugin

### DIFF
--- a/app/models/foreman_virt_who_configure/config.rb
+++ b/app/models/foreman_virt_who_configure/config.rb
@@ -258,10 +258,6 @@ module ForemanVirtWhoConfigure
       end
     end
 
-    def virt_who_config_command
-      "hammer virt-who-config deploy --id #{id} --organization-id #{organization_id}"
-    end
-
     def virt_who_touch!
       self.last_report_at = DateTime.now.utc
       self.out_of_date_at = last_report_at + interval.minutes

--- a/app/views/foreman_virt_who_configure/configs/show.html.erb
+++ b/app/views/foreman_virt_who_configure/configs/show.html.erb
@@ -64,29 +64,13 @@
       <div class="form-group">
         <div class="row">
           <div class="col-md-6">
-            <%= _("Use either hammer command or the script below to deploy this configuration. Both require root privileges. Run one of them on the target host which has access to katello-host-tools repository and will run virt-who reporting, preferably Foreman host:") %>
+            <%= _("Use the script below to deploy this configuration. It requires root privileges. Run it on the target host which has access to katello-host-tools repository and will run virt-who reporting, preferably the smart proxy:") %>
           </div>
         </div>
 
         <div class="row">
           <div class="col-md-12">
-            <h3><%= 'a) ' + _('Hammer command: ') %></h3>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-md-8">
-            <pre class="terminal" id="config_command"><%= @config.virt_who_config_command %></pre>
-          </div>
-          <div class="col-md-8">
-            <div class="terminal-buttons">
-              <%= link_to _('Copy to clipboard'), '#', :class => 'btn btn-default', :onclick => 'virt_who_copy_configuration_to_clipboard($("#config_command").text()); return false' %>
-            </div>
-          </div>
-        </div>
-
-        <div class="row">
-          <div class="col-md-12">
-            <h3><%= 'b) ' + _('Configuration script: ') %></h3>
+            <h3><%= _('Configuration script: ') %></h3>
           </div>
           <div class="col-md-8">
             <p>

--- a/claude.md
+++ b/claude.md
@@ -63,7 +63,7 @@ This plugin provides a user-friendly web interface and API for:
 #### Deployment
 - Generates shell scripts for automated virt-who installation and configuration
 - Supports both manual deployment and configuration management integration
-- Provides Hammer CLI command examples for automation
+- Provides deployment scripts for automation
 
 ### Database Schema
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

* Removed all references of hammer in the plugin and the UI
* Updated the `.pot` file for translations when we push them to transifex next time
* Updated the `CLAUDE.md` file to remove references of hammer

#### Considerations taken when implementing this change?

* Kept the bash script for now until we change that over to Ansible

#### What are the testing steps for this pull request?

* Check out PR
* Try to create a config, can put fake data in all the fields since you are not deploying it
* Check to see hammer deploy option is removed from the UI